### PR TITLE
Fix invalid PDF due to extra line in spoolfile

### DIFF
--- a/cups-pdf.c
+++ b/cups-pdf.c
@@ -748,7 +748,6 @@ static int preparespoolfile(FILE *fpsrc, char *spoolfile, char *title, char *cmd
   (void) fputs(buffer, fpdest);
 
   if (input_is_pdf) {
-    fwrite(buffer, sizeof(char), 4, fpdest);
     while((bytes = fread(buffer, sizeof(char), BUFSIZE, fpsrc)) > 0)
       fwrite(buffer, sizeof(char), bytes, fpdest);
   } else {


### PR DESCRIPTION
The removed `fwrite` was adding an unnecessary `%PDF` at the second line of the spoolfile. Some Acrobat Reader versions would refuse to open those files. The validation tool at https://www.pdf-online.com/osa/validate.aspx was also reporting errors.

Before this commit:

```
qwe@qwe:/var/spool/cups-pdf/SPOOL$ head -n 2 cups2pdf-8786
%PDF-1.5
%PDF%����
```

After:

```
qwe@qwe:/var/spool/cups-pdf/SPOOL$ head -n 2 cups2pdf-9002
%PDF-1.5
%����
```